### PR TITLE
(WIP) Pass parsed docstring object to Mako template

### DIFF
--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -151,9 +151,9 @@ class Doc(object):
         """
 
         try:
-            self.parsed_docsting = docstring_parser.parse(self.docstring)
+            self.parsed_docstring = docstring_parser.parse(self.docstring)
         except docstring_parser.ParseError:
-            self.parsed_docsting = None
+            self.parsed_docstring = None
         """
         The parsed docstring for this object.
         """

--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -280,6 +280,7 @@ class Module(Doc):
             if isinstance(dobj, External):
                 continue
             dobj.docstring = inspect.cleandoc(docstring)
+            dobj.parsed_docstring = docstring_parser.parse(dobj.docstring)
 
     @property
     def source(self):

--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -2,6 +2,8 @@ import ast
 import inspect
 import typing
 
+import docstring_parser
+
 __pdoc__ = {}
 
 
@@ -146,6 +148,14 @@ class Doc(object):
         """
         The docstring for this object. It has already been cleaned
         by `inspect.cleandoc`.
+        """
+
+        try:
+            self.parsed_docsting = docstring_parser.parse(self.docstring)
+        except docstring_parser.ParseError:
+            self.parsed_docsting = None
+        """
+        The parsed docstring for this object.
         """
 
     @property

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -17,13 +17,24 @@ def ${func.name}(
 )${returns}
 ```
 % if hasattr(func, 'parsed_docstring') and func.parsed_docstring:
-    # table with arguments info
-    % if func.parsed_docstring.params:
-| Parameter | type | description | default |
+<% parsed_ds = func.parsed_docstring %>
+    % if parsed_ds.params:
+**Parameters:**
+
+| Name | Type | Description | Default |
 |---|---|---|---|
-        % for p in func.parsed_docstring.params:
+        % for p in parsed_ds.params:
 | ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
         % endfor
+    % endif
+    % if parsed_ds.returns:
+<% ret = parsed_ds.returns %>
+
+**Returns:**
+
+| Type | Description |
+|---|---|
+| ${ret.type_name} | ${ret.description} |
     % endif
 % else:
 ${func.docstring}

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -41,7 +41,7 @@ ${func.docstring}
 ```python3
 ${var.name}
 ```
-% if hasattr(var, 'parsed_docstring') and var.parsed_docsting:
+% if hasattr(var, 'parsed_docstring') and var.parsed_docstring:
     # table with arguments info
     % if var.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -16,7 +16,7 @@ def ${func.name}(
     ${",\n    ".join(func.params())}
 )${returns}
 ```
-% if hasattr(func, 'parsed_docstring') and func.parsed_docsting:
+% if hasattr(func, 'parsed_docstring') and func.parsed_docstring:
     # table with arguments info
     % if func.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -16,7 +16,18 @@ def ${func.name}(
     ${",\n    ".join(func.params())}
 )${returns}
 ```
+% if func.parsed_docstring:
+    # table with arguments info
+    % if func.parsed_docstring.params:
+| Parameter | type | description | default |
+|---|---|---|---|
+        % for p in func.parsed_docstring.params:
+| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+        % endfor
+    % endif
+% else:
 ${func.docstring}
+% endif
 
 % if show_source_code and func.source:
 
@@ -30,7 +41,19 @@ ${func.docstring}
 ```python3
 ${var.name}
 ```
+% if var.parsed_docstring:
+    # table with arguments info
+    % if var.parsed_docstring.params:
+| Parameter | type | description | default |
+|---|---|---|---|
+        % for p in var.parsed_docstring.params:
+| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+        % endfor
+    % endif
+% else:
 ${var.docstring}
+% endif
+
 </%def>
 
 <%def name="class_(cls)" buffered="True">
@@ -42,7 +65,18 @@ class ${cls.name}(
 )
 ```
 
+% if cls.parsed_docstring:
+    # table with arguments info
+    % if cls.parsed_docstring.params:
+| Parameter | type | description | default |
+|---|---|---|---|
+        % for p in cls.parsed_docstring.params:
+| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+        % endfor
+    % endif
+% else:
 ${cls.docstring}
+% endif
 
 % if show_source_code and cls.source:
 

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -16,7 +16,7 @@ def ${func.name}(
     ${",\n    ".join(func.params())}
 )${returns}
 ```
-% if func.parsed_docstring:
+% if hasattr(func, 'parsed_docstring') and func.parsed_docsting:
     # table with arguments info
     % if func.parsed_docstring.params:
 | Parameter | type | description | default |
@@ -41,7 +41,7 @@ ${func.docstring}
 ```python3
 ${var.name}
 ```
-% if var.parsed_docstring:
+% if hasattr(var, 'parsed_docstring') and var.parsed_docsting:
     # table with arguments info
     % if var.parsed_docstring.params:
 | Parameter | type | description | default |
@@ -65,7 +65,7 @@ class ${cls.name}(
 )
 ```
 
-% if cls.parsed_docstring:
+% if hasattr(cls, 'parsed_docstring') and cls.parsed_docsting:
     # table with arguments info
     % if cls.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -65,7 +65,7 @@ class ${cls.name}(
 )
 ```
 
-% if hasattr(cls, 'parsed_docstring') and cls.parsed_docsting:
+% if hasattr(cls, 'parsed_docstring') and cls.parsed_docstring:
     # table with arguments info
     % if cls.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.6"
 Markdown = "^3.0.0"
 Mako = "^1.1"
 hug = "^2.6"
+docstring_parser = "^0.7.2"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.720.0"
@@ -30,12 +31,12 @@ pep8-naming = "^0.8.2"
 [tool.poetry.scripts]
 pdocs = "pdocs.cli:__hug__.cli"
 
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
 [tool.portray.mkdocs.theme]
 favicon = "art/logo.png"
 logo = "art/logo.png"
 name = "material"
 palette = {primary = "deep purple", accent = "pink"}
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+


### PR DESCRIPTION
This PR aims to fix #4 by using [`docstring_parser`](https://github.com/rr-/docstring_parser) to parse various types of docstrings (it claims it supports ReST, Google, and Numpydoc-style docstrings) and pass the parsed object to the Mako template.

I figured out some Mako syntax errors, but I'm still getting issues with the new `parsed_docstring` object not being on the object passed to Mako and haven't figure out where to add it yet.

```
> pdocs as_markdown -ov rio_tiler
Traceback (most recent call last):
  File "/Users/kyle/local/anaconda3/bin/pdocs", line 8, in <module>
    sys.exit(__hug__.cli())
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/hug/api.py", line 441, in __call__
    result = self.commands.get(command)()
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/hug/interface.py", line 650, in __call__
    raise exception
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/hug/interface.py", line 646, in __call__
    result = self.output(self.interface(**pass_to_function), context)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/hug/interface.py", line 129, in __call__
    return __hug_internal_self._function(*args, **kwargs)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/pdocs/api.py", line 83, in as_markdown
    pdocs.static.md_out(destination, roots, source=not exclude_source)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/pdocs/static.py", line 88, in md_out
    out = pdocs.render.text(m, source=source)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/pdocs/render.py", line 86, in text
    text, _ = re.subn("\n\n\n+", "\n\n", t.render(module=mod, show_source_code=source).strip())
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/mako/template.py", line 476, in render
    return runtime._render(self, self.callable_, args, data)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/Users/kyle/local/anaconda3/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "_text_mako", line 77, in render_body
  File "_text_mako", line 27, in function
  File "_text_mako", line 124, in render_function
AttributeError: 'Function' object has no attribute 'parsed_docstring'
```

cc @sanzoghenzo