### PR TITLE
Parse docstring

### DIFF
--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -151,9 +151,9 @@ class Doc(object):
         """
 
         try:
-            self.parsed_docsting = docstring_parser.parse(self.docstring)
+            self.parsed_docstring = docstring_parser.parse(self.docstring)
         except docstring_parser.ParseError:
-            self.parsed_docsting = None
+            self.parsed_docstring = None
         """
         The parsed docstring for this object.
         """

--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -280,6 +280,7 @@ class Module(Doc):
             if isinstance(dobj, External):
                 continue
             dobj.docstring = inspect.cleandoc(docstring)
+            dobj.parsed_docstring = docstring_parser.parse(dobj.docstring)
 
     @property
     def source(self):

--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -280,7 +280,10 @@ class Module(Doc):
             if isinstance(dobj, External):
                 continue
             dobj.docstring = inspect.cleandoc(docstring)
-            dobj.parsed_docstring = docstring_parser.parse(dobj.docstring)
+            try:
+                dobj.parsed_docstring = docstring_parser.parse(dobj.docstring)
+            except docstring_parser.ParseError:
+                dobj.parsed_docstring = None
 
     @property
     def source(self):

--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -2,6 +2,8 @@ import ast
 import inspect
 import typing
 
+import docstring_parser
+
 __pdoc__ = {}
 
 
@@ -146,6 +148,14 @@ class Doc(object):
         """
         The docstring for this object. It has already been cleaned
         by `inspect.cleandoc`.
+        """
+
+        try:
+            self.parsed_docsting = docstring_parser.parse(self.docstring)
+        except docstring_parser.ParseError:
+            self.parsed_docsting = None
+        """
+        The parsed docstring for this object.
         """
 
     @property

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -17,13 +17,24 @@ def ${func.name}(
 )${returns}
 ```
 % if hasattr(func, 'parsed_docstring') and func.parsed_docstring:
-    # table with arguments info
-    % if func.parsed_docstring.params:
-| Parameter | type | description | default |
+<% parsed_ds = func.parsed_docstring %>
+    % if parsed_ds.params:
+**Parameters:**
+
+| Name | Type | Description | Default |
 |---|---|---|---|
-        % for p in func.parsed_docstring.params:
+        % for p in parsed_ds.params:
 | ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
         % endfor
+    % endif
+    % if parsed_ds.returns:
+<% ret = parsed_ds.returns %>
+
+**Returns:**
+
+| Type | Description |
+|---|---|
+| ${ret.type_name} | ${ret.description} |
     % endif
 % else:
 ${func.docstring}

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -41,7 +41,7 @@ ${func.docstring}
 ```python3
 ${var.name}
 ```
-% if hasattr(var, 'parsed_docstring') and var.parsed_docsting:
+% if hasattr(var, 'parsed_docstring') and var.parsed_docstring:
     # table with arguments info
     % if var.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -16,7 +16,7 @@ def ${func.name}(
     ${",\n    ".join(func.params())}
 )${returns}
 ```
-% if hasattr(func, 'parsed_docstring') and func.parsed_docsting:
+% if hasattr(func, 'parsed_docstring') and func.parsed_docstring:
     # table with arguments info
     % if func.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -16,7 +16,18 @@ def ${func.name}(
     ${",\n    ".join(func.params())}
 )${returns}
 ```
+% if func.parsed_docstring:
+    # table with arguments info
+    % if func.parsed_docstring.params:
+| Parameter | type | description | default |
+|---|---|---|---|
+        % for p in func.parsed_docstring.params:
+| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+        % endfor
+    % endif
+% else:
 ${func.docstring}
+% endif
 
 % if show_source_code and func.source:
 
@@ -30,7 +41,19 @@ ${func.docstring}
 ```python3
 ${var.name}
 ```
+% if var.parsed_docstring:
+    # table with arguments info
+    % if var.parsed_docstring.params:
+| Parameter | type | description | default |
+|---|---|---|---|
+        % for p in var.parsed_docstring.params:
+| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+        % endfor
+    % endif
+% else:
 ${var.docstring}
+% endif
+
 </%def>
 
 <%def name="class_(cls)" buffered="True">
@@ -42,7 +65,18 @@ class ${cls.name}(
 )
 ```
 
+% if cls.parsed_docstring:
+    # table with arguments info
+    % if cls.parsed_docstring.params:
+| Parameter | type | description | default |
+|---|---|---|---|
+        % for p in cls.parsed_docstring.params:
+| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+        % endfor
+    % endif
+% else:
 ${cls.docstring}
+% endif
 
 % if show_source_code and cls.source:
 

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -16,7 +16,7 @@ def ${func.name}(
     ${",\n    ".join(func.params())}
 )${returns}
 ```
-% if func.parsed_docstring:
+% if hasattr(func, 'parsed_docstring') and func.parsed_docsting:
     # table with arguments info
     % if func.parsed_docstring.params:
 | Parameter | type | description | default |
@@ -41,7 +41,7 @@ ${func.docstring}
 ```python3
 ${var.name}
 ```
-% if var.parsed_docstring:
+% if hasattr(var, 'parsed_docstring') and var.parsed_docsting:
     # table with arguments info
     % if var.parsed_docstring.params:
 | Parameter | type | description | default |
@@ -65,7 +65,7 @@ class ${cls.name}(
 )
 ```
 
-% if cls.parsed_docstring:
+% if hasattr(cls, 'parsed_docstring') and cls.parsed_docsting:
     # table with arguments info
     % if cls.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -65,7 +65,7 @@ class ${cls.name}(
 )
 ```
 
-% if hasattr(cls, 'parsed_docstring') and cls.parsed_docsting:
+% if hasattr(cls, 'parsed_docstring') and cls.parsed_docstring:
     # table with arguments info
     % if cls.parsed_docstring.params:
 | Parameter | type | description | default |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.6"
 Markdown = "^3.0.0"
 Mako = "^1.1"
 hug = "^2.6"
+docstring_parser = "^0.7.2"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.720.0"
@@ -30,12 +31,12 @@ pep8-naming = "^0.8.2"
 [tool.poetry.scripts]
 pdocs = "pdocs.cli:__hug__.cli"
 
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
 [tool.portray.mkdocs.theme]
 favicon = "art/logo.png"
 logo = "art/logo.png"
 name = "material"
 palette = {primary = "deep purple", accent = "pink"}
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+

--- a/tests/docstring_parser/example_google.py
+++ b/tests/docstring_parser/example_google.py
@@ -1,0 +1,114 @@
+"""Module level docstring."""
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Tuple
+
+#: The first module level attribute. Comment *before* attribute.
+first_attribute: int = 1
+second_attribute = "abc"  #: str: The second module level attribute. *Inline* style.
+third_attribute: List[int] = [1, 2, 3]
+"""The third module level attribute. Docstring *after* attribute.
+
+Multiple paragraphs are supported.
+"""
+not_attribute = 123  # Not attribute description because ':' is missing.
+
+
+def add(x: int, y: int = 1) -> int:
+    """Return $x + y$.
+
+    Args:
+        x: The first parameter.
+        y: The second parameter. Default={default}.
+
+    Returns:
+        int: Added value.
+
+    Examples:
+        Examples should be written in doctest format.
+
+        >>> add(1, 2)
+        3
+
+    !!! note
+        You can use the [Admonition extension of
+        MkDocs](https://squidfunk.github.io/mkdocs-material/extensions/admonition/).
+
+    Note:
+        `Note` section is converted into the Admonition.
+    """
+    return x + y
+
+
+def gen(n) -> Iterator[str]:
+    """Yield a numbered string.
+
+    Args:
+        n (int): The length of iteration.
+
+    Yields:
+       str: A numbered string.
+    """
+    for x in range(n):
+        yield f"a{x}"
+
+
+class ExampleClass:
+    """A normal class.
+
+    Args:
+        x: The first parameter.
+        y: The second parameter.
+
+    Raises:
+        ValueError: If the length of `x` is equal to 0.
+    """
+
+    def __init__(self, x: List[int], y: Tuple[str, int]):
+        if len(x) == 0:
+            raise ValueError()
+        self.a: str = "abc"  #: The first attribute. Comment *inline* with attribute.
+        #: The second attribute. Comment *before* attribute.
+        self.b: Dict[str, int] = {"a": 1}
+        self.c = None
+        """int, optional: The third attribute. Docstring *after* attribute.
+
+        Multiple paragraphs are supported."""
+        self.d = 100  # Not attribute description because ':' is missing.
+
+    def message(self, n: int) -> List[str]:
+        """Return a message list.
+
+        Args:
+            n: Repetition.
+        """
+        return [self.a] * n
+
+    @property
+    def readonly_property(self):
+        """str: Read-only property documentation."""
+        return "readonly property"
+
+    @property
+    def readwrite_property(self) -> List[int]:
+        """Read-write property documentation."""
+        return [1, 2, 3]
+
+    @readwrite_property.setter
+    def readwrite_property(self, value):
+        """Docstring in setter is ignored."""
+
+
+@dataclass
+class ExampleDataClass:
+    """A dataclass.
+
+    Args:
+        x: The first parameter.
+
+    Attributes:
+        x: The first attribute.
+        y: The second attribute.
+    """
+
+    x: int = 0
+    y: int = field(default=1, init=False)

--- a/tests/docstring_parser/example_numpy.py
+++ b/tests/docstring_parser/example_numpy.py
@@ -1,0 +1,128 @@
+"""Module level docstring."""
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Tuple
+
+
+def add(x: int, y: int = 1) -> int:
+    """Return $x + y$.
+
+    Parameters
+    ----------
+    x
+        The first parameter.
+    y
+        The second parameter. Default={default}.
+
+    Returns
+    -------
+    int
+        Added value.
+
+        !!! note
+            The return type must be duplicated in the docstring to comply with the NumPy
+            docstring style.
+
+    Examples
+    --------
+    Examples should be written in doctest format.
+
+    >>> add(1, 2)
+    3
+
+    Note
+    ----
+        MkApi doesn't check an underline that follows a section heading.
+        Just skip one line.
+    """
+    return x + y
+
+
+def gen(n) -> Iterator[str]:
+    """Yield a numbered string.
+
+    Parameters
+    ----------
+    n : int
+        The length of iteration.
+
+    Yields
+    ------
+    str
+        A numbered string.
+    """
+    for x in range(n):
+        yield f"a{x}"
+
+
+class ExampleClass:
+    """A normal class.
+
+    Parameters
+    ----------
+    x
+        The first parameter.
+    y
+        The second parameter.
+
+    Raises
+    ------
+    ValueError
+        If the length of `x` is equal to 0.
+    """
+
+    def __init__(self, x: List[int], y: Tuple[str, int]):
+        if len(x) == 0:
+            raise ValueError()
+        self.a: str = "abc"  #: The first attribute. Comment *inline* with attribute.
+        #: The second attribute. Comment *before* attribute.
+        self.b: Dict[str, int] = {"a": 1}
+        self.c = None
+        """int, optional: The third attribute. Docstring *after* attribute.
+
+        Multiple paragraphs are supported."""
+        self.d = 100  # Not attribute description because ':' is missing.
+
+    def message(self, n: int) -> List[str]:
+        """Return a message list.
+
+        Parameters
+        ----------
+        n
+            Repetition.
+        """
+        return [self.a] * n
+
+    @property
+    def readonly_property(self):
+        """str: Read-only property documentation."""
+        return "readonly property"
+
+    @property
+    def readwrite_property(self) -> List[int]:
+        """Read-write property documentation."""
+        return [1, 2, 3]
+
+    @readwrite_property.setter
+    def readwrite_property(self, value):
+        """Docstring in setter is ignored."""
+
+
+@dataclass
+class ExampleDataClass:
+    """A dataclass.
+
+    Parameters
+    ----------
+    x
+        The first parameter.
+
+    Attributes
+    ----------
+    x
+        The first attribute.
+    y
+        The second attribute.
+    """
+
+    x: int = 0
+    y: int = field(default=1, init=False)

--- a/tests/test_parse_docstring.py
+++ b/tests/test_parse_docstring.py
@@ -1,0 +1,190 @@
+from pdocs import doc
+from tests import tutils
+import pdocs
+
+
+def simple_function(arg1, arg2=1):
+    """
+    Just a simple function.
+
+    Args:
+      arg1 (str): first argument
+      arg2 (int): second argument
+
+    Returns:
+      List[str]: first argument repeated second argument types.
+    """
+    return [arg1] * arg2
+
+
+def test_parse_docstring():
+    fun_doc = doc.Function("simple_function", __name__, simple_function)
+    assert fun_doc.parsed_docstring is not None
+    parsed = fun_doc.parsed_docstring
+    assert len(parsed.params) == 2
+    first_param, second_param = parsed.params
+    assert first_param.arg_name == "arg1"
+    assert first_param.type_name == "str"
+    assert first_param.description == "first argument"
+    assert first_param.is_optional == False
+    assert second_param.arg_name == "arg2"
+    assert second_param.type_name == "int"
+    assert second_param.description == "second argument"
+    # assert second_param.is_optional == True
+    # assert second_param.default == 1
+
+
+def token_to_alias(raw_text, vocab):
+    """
+    Replaces known tokens with their "tag" form.
+    
+    i.e. the alias' in some known vocabulary list.
+
+    Parameters
+    ----------
+    raw_text: pd.Series
+        contains text with known jargon, slang, etc
+    vocab: pd.DataFrame
+        contains alias' keyed on known slang, jargon, etc.
+
+    Returns
+    -------
+    pd.Series
+        new text, with all slang/jargon replaced with unified representations
+    """
+    pass
+
+
+def test_numpydocs():
+    fun_doc = doc.Function("token_to_alias", __name__, token_to_alias)
+    assert fun_doc.parsed_docstring is not None
+    parsed = fun_doc.parsed_docstring
+    assert parsed.short_description == 'Replaces known tokens with their "tag" form.'
+    assert len(parsed.params) == 2
+    assert len(parsed.raises) == 0
+    first_param, second_param = parsed.params
+    assert first_param.arg_name == "raw_text"
+    assert first_param.type_name == "pd.Series"
+    assert first_param.description == "contains text with known jargon, slang, etc"
+    assert first_param.is_optional == False
+    assert second_param.arg_name == "vocab"
+    assert second_param.type_name == "pd.DataFrame"
+    assert second_param.description == "contains alias' keyed on known slang, jargon, etc."
+    assert second_param.is_optional == False
+    returns = parsed.returns
+    assert returns.description == "new text, with all slang/jargon replaced with unified representations"
+    assert returns.return_name is None
+    assert returns.type_name == "pd.Series"
+    assert not returns.is_generator
+
+
+def test_parse_numpy_example():
+    with tutils.tdir():
+        m = pdocs.extract.extract_module(f"./docstring_parser/example_numpy.py")
+    
+    assert m.parsed_docstring
+    pd = m.parsed_docstring
+    assert pd.short_description == "Module level docstring."
+    assert not pd.long_description
+
+    assert "add" in m.doc
+    add_pd = m.doc["add"].parsed_docstring
+    assert add_pd.short_description == "Return $x + y$."
+    assert len(add_pd.params) == 2
+    x, y = add_pd.params
+    assert x.description == "The first parameter."
+    assert y.description == "The second parameter. Default={default}."
+    assert add_pd.returns.type_name == "int"
+    assert add_pd.returns.description == """Added value.
+
+!!! note
+    The return type must be duplicated in the docstring to comply with the NumPy
+    docstring style."""
+
+    assert "gen" in m.doc
+    gen_pd = m.doc["gen"].parsed_docstring
+    assert gen_pd.short_description == "Yield a numbered string."
+    n, = gen_pd.params
+    assert n.description == "The length of iteration."
+    assert n.type_name == "int"
+    assert n.arg_name == "n"
+    assert gen_pd.returns.type_name == "str"
+    assert gen_pd.returns.is_generator
+    assert gen_pd.returns.description == "A numbered string."
+
+    assert "ExampleClass" in m.doc
+    ex_class = m.doc["ExampleClass"]
+    ec_pd = ex_class.parsed_docstring
+    assert ec_pd.short_description == "A normal class."
+    x, y = ec_pd.params
+    assert x.description == "The first parameter."
+    assert y.description == "The second parameter."
+    assert len(ec_pd.raises) == 1
+    raises = ec_pd.raises[0]
+    assert raises.type_name == "ValueError"
+    assert raises.description == "If the length of `x` is equal to 0."
+    msg_pd = ex_class.doc["message"].parsed_docstring
+    assert msg_pd.short_description == "Return a message list."
+    n = msg_pd.params[0]
+    assert n.arg_name == "n"
+    assert n.description == "Repetition."
+    assert "readonly_property" in ex_class.doc_init
+    ro_prop_pd = ex_class.doc_init["readonly_property"].parsed_docstring
+    assert ro_prop_pd.short_description == "str: Read-only property documentation."
+    assert "readwrite_property" in ex_class.doc_init
+    rw_prop_pd = ex_class.doc_init["readwrite_property"].parsed_docstring
+    assert rw_prop_pd.short_description == "Read-write property documentation."
+
+
+def test_parse_google_example():
+    with tutils.tdir():
+        m = pdocs.extract.extract_module(f"./docstring_parser/example_google.py")
+    
+    assert m.parsed_docstring
+    pd = m.parsed_docstring
+    assert pd.short_description == "Module level docstring."
+    assert not pd.long_description
+
+    assert "add" in m.doc
+    add_pd = m.doc["add"].parsed_docstring
+    assert add_pd.short_description == "Return $x + y$."
+    assert len(add_pd.params) == 2
+    x, y = add_pd.params
+    assert x.description == "The first parameter."
+    assert y.description == "The second parameter. Default={default}."
+    assert add_pd.returns.type_name == "int"
+    assert add_pd.returns.description == "Added value."
+
+    assert "gen" in m.doc
+    gen_pd = m.doc["gen"].parsed_docstring
+    assert gen_pd.short_description == "Yield a numbered string."
+    n, = gen_pd.params
+    assert n.description == "The length of iteration."
+    assert n.type_name == "int"
+    assert n.arg_name == "n"
+    assert gen_pd.returns.type_name == "str"
+    assert gen_pd.returns.is_generator
+    assert gen_pd.returns.description == "A numbered string."
+
+    assert "ExampleClass" in m.doc
+    ex_class = m.doc["ExampleClass"]
+    ec_pd = ex_class.parsed_docstring
+    assert ec_pd.short_description == "A normal class."
+    x, y = ec_pd.params
+    assert x.description == "The first parameter."
+    assert y.description == "The second parameter."
+    assert len(ec_pd.raises) == 1
+    raises = ec_pd.raises[0]
+    assert raises.type_name == "ValueError"
+    assert raises.description == "If the length of `x` is equal to 0."
+    msg_pd = ex_class.doc["message"].parsed_docstring
+    assert msg_pd.short_description == "Return a message list."
+    n = msg_pd.params[0]
+    assert n.arg_name == "n"
+    assert n.description == "Repetition."
+    assert "readonly_property" in ex_class.doc_init
+    ro_prop_pd = ex_class.doc_init["readonly_property"].parsed_docstring
+    assert ro_prop_pd.short_description == "str: Read-only property documentation."
+    assert "readwrite_property" in ex_class.doc_init
+    rw_prop_pd = ex_class.doc_init["readwrite_property"].parsed_docstring
+    assert rw_prop_pd.short_description == "Read-write property documentation."


### PR DESCRIPTION
This is the continuation of the work made in #10 by @kylebarron

It closes #4 and adds NumPy and Google style docstrings parsing.

ReST style docstring should be parsed also, but they aren't tested.

To speed up the testing, I used MkAPI docstring examples.

I also added the `class_level` parameter to `text.mako`'s `function` as done in `portray`.

There's still room from improvements: for example, when using typing annotations, parameters/return types and defaults are not detected.