### PR TITLE
Replace \n by <br> in table to avoid a poorly rendering for the table in markdown

### DIFF
--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -50,7 +50,7 @@ ${long_desc}
 | Name | Type | Description | Default |
 |---|---|---|---|
         % for p in params:
-| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+| ${p.arg_name} | ${p.type_name} | ${p.description.replace('\n', '<br>')} | ${p.default} |
         % endfor
     % endif
 
@@ -61,7 +61,7 @@ ${long_desc}
 | Type | Description |
 |---|---|
 ## TODO: handle multiline descriptions
-| ${ret.type_name} | ${ret.description} |
+| ${ret.type_name} | ${ret.description.replace('\n', '<br>')} |
     % endif
     % if raises:
 
@@ -71,7 +71,7 @@ ${long_desc}
 |---|---|
         % for r in raises:
 ## TODO: handle multiline descriptions
-| ${r.type_name} | ${r.description} |
+| ${r.type_name} | ${r.description.replace('\n', '<br>')} |
         % endfor
     % endif
 % else:
@@ -126,7 +126,7 @@ ${h4("Attributes")}
 | Name | Type | Description | Default |
 |---|---|---|---|
         % for p in cls.parsed_docstring.params:
-| ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
+| ${p.arg_name} | ${p.type_name} | ${p.description.replace('\n', '<br>')} | ${p.default} |
         % endfor
     % endif
 % else:


### PR DESCRIPTION
docstring_parser has been a nice introduction which allows the usage of Google format.

However, the rendering of the table isn't convincing.

If my dosctring is written as follow:

```python
   """
    Arguments:
        weights: a list of Numpy arrays. The number
            of arrays and their shape must match
            number of the dimensions of the weights
            of the layer (i.e. it should match the
            output of `get_weights`).
    """
```
The doc will be the following:

<img width="714" alt="Capture d’écran 2021-02-07 à 20 45 06" src="https://user-images.githubusercontent.com/9768541/107157620-61f5d600-6985-11eb-8f6e-d87ebcae5cc6.png">

The issue is that `\n` isn't supposed to be used in a table with markdown. `<br>` could be used instead.

<img width="592" alt="Capture d’écran 2021-02-07 à 20 51 12" src="https://user-images.githubusercontent.com/9768541/107157755-39baa700-6986-11eb-8482-4bd56e38f19a.png">

In this PR, I propose to do a quick modification of `text.mako`in order to replace the `\n`by `<br>`to fix the issue.

I don't really know the codebase. If you have a better fix, I'll be happy to do it.
