### PR TITLE
fix #22 remove "None" from markdown output

### DIFF
--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -8,6 +8,12 @@
 </%def>
 <%def name="h4(s)">#### ${s}
 </%def>
+<%def name="par(s)">
+% if s:
+${s}
+
+% endif
+</%def>
 
 <%def name="function(func, class_level=False)" buffered="True">
     <%
@@ -36,14 +42,9 @@ def ${func.name}(
         ret = parsed_ds.returns
         raises = parsed_ds.raises
     %>
-    % if short_desc:
-${short_desc}
+${par(short_desc)}
+${par(long_desc)}
 
-    % endif
-    % if long_desc:
-${long_desc}
-
-    % endif
     % if params:
 **Parameters:**
 
@@ -97,13 +98,8 @@ ${var.name}
         long_desc = var_pd.long_description
 %>
 % if var_pd:
-    % if short_desc:
-${short_desc}
-
-    % endif
-    %if long_desc:
-${long_desc}
-    % endif
+${par(short_desc)}
+${par(long_desc)}
 % else:
 ${var.docstring}
 % endif
@@ -210,9 +206,8 @@ ${function(m, True)}
 
 ${h1(heading + " " + module.name)}
 % if parsed_ds:
-${parsed_ds.short_description}
-
-${parsed_ds.long_description}
+${par(parsed_ds.short_description)}
+${par(parsed_ds.long_description)}
 ## TODO: add meta (example and notes)
 % else:
 ${module.docstring}


### PR DESCRIPTION
Fixes #22

Without this change, the rendered documentation has random "None" text, which can be confusing

I implemented a paragraph function (`par()`) that makes the text template a little DRY'r. I've tested this fix locally with a custom template ([calcipy/../text.mako](https://github.com/KyleKing/calcipy/commit/68541b437393f3254ef4c2d24ac1998dddf4cd1c))

![Example](https://user-images.githubusercontent.com/3784339/107566570-0ad54880-6bb3-11eb-84ba-fb4cc673d243.jpg)