### PR TITLE
Handle CRLF & whitespace for markdown output

### DIFF
--- a/pdocs/render.py
+++ b/pdocs/render.py
@@ -82,6 +82,6 @@ def text(mod: pdocs.doc.Module, source: bool = True) -> str:
 
     *source* - If set to True (the default) source will be included in the produced output.
     """
-    t = _get_tpl("/text.mako")
-    text, _ = re.subn("\n\n\n+", "\n\n", t.render(module=mod, show_source_code=source).strip())
+    raw_text = _get_tpl("/text.mako").render(module=mod, show_source_code=source)
+    text, _ = re.subn("\n *\n *\n+", "\n\n", raw_text.strip().replace('\r\n', '\n'))
     return text


### PR DESCRIPTION
On Windows, the final rendered pdocs output might look like this: `# Module Name   \r\n   \r\n\r\n   \r\n```\r\ndef function`. The extra carriage returns and leading whitespace aren't removed, so tables and code blocks aren't valid markdown.

This PR is a very minor fix that first standardizes on newline-only line endings (remove carriage returns) then escapes optional internal spaces. If needed, I can add a fix to re-add carriage returns, but that doesn't appear to be necessary when testing on Windows and Mac.

I've been testing these changes as part of my [calcipy project](https://calcipy.kyleking.me/modules/calcipy/doit_tasks/)