### PR TITLE
Give user more info when an import fails

### DIFF
--- a/pdocs/extract.py
+++ b/pdocs/extract.py
@@ -68,8 +68,8 @@ def load_module(basedir: str, module: str) -> typing.Tuple[typing.Any, bool]:
         try:
             # This can literally raise anything
             m = importlib.import_module(module)
-        except ImportError:
-            raise ExtractError("Module not found: {module}".format(module=module))
+        except ImportError as e:
+            raise ExtractError("Could not import module {module}: {e}".format(module=module, e=e))
         except Exception as e:
             raise ExtractError("Error importing {module}: {e}".format(module=module, e=e))
         # This is the only case where we actually have to test whether we're a package


### PR DESCRIPTION
Failing with the error `module not found` without any supplementary info
leaves the user quite puzzled about how to fix the issue. Update the
error message so that the import error is printed. This gives something
like `could not import module X: No module named '<Y>'`, where `<Y>`
would be the actual missing module (not `pip install`ed, bad path config,
etc.).

I'm setting this PR to draft because there's a different solution that I like better but would like to discuss with you first. Some of my errors while using portray could not be tracked down even with the information I've added; I actually needed the whole stack trace. The best way to get the stack trace is to just *completely remove* the try/except here. Then it fails loudly with lots of extra information. But is there perhaps a specific reason that the re-throw with `ExtractError` mechanism is being used now?