### PR TITLE
Fix GenericAlias __subclasses__ check

### DIFF
--- a/pdocs/doc.py
+++ b/pdocs/doc.py
@@ -4,6 +4,11 @@ import typing
 
 import docstring_parser
 
+try:  # python >= 3.9
+    from types import GenericAlias
+except ImportError:  # python >= 3.7
+    from typing import _GenericAlias as GenericAlias
+
 __pdoc__ = {}
 
 
@@ -615,6 +620,8 @@ class Class(Doc):
 
     def subclasses(self):
         """Returns back all subclasses of this class"""
+        if isinstance(self.cls, GenericAlias):
+            return []
         return [self.module.find_class(cls) for cls in type.__subclasses__(self.cls)]
 
     def __public_objs(self):


### PR DESCRIPTION
When using a type alias such as `Ints = list[int]`, pdocs will error with:
```
TypeError: descriptor '__subclasses__' for 'type' objects doesn't apply to a 'types.GenericAlias' object
```

Abstractly, some GenericAliases might have subclasses (eg: either direct like `class X(list[int])` or "logically" as `list[int]` being a subclass of `list[int | float]`), but regardless they're not enumerable as other classes are. This PR just returns an empty list when trying to inspect the subclasses.