### PR TITLE
Fix deprecated allows-prereleases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ flake8-bugbear = "^19.8"
 bandit = "^1.6"
 vulture = "^1.0"
 safety = "^1.8"
-black = {version = "^18.3-alpha.0", allows-prereleases = true}
+black = {version = "^18.3-alpha.0", allow-prereleases = true}
 pytest-mock = "^1.10"
 ipython = "^7.7"
 flake8 = "^3.7"


### PR DESCRIPTION
The poetry dep `allows-prereleases` spec has been deprecated and renamed to `allow-prereleases`, causing a warning when building the package:
```
The "black" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
```