### PR TITLE
Relax dataclasses pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ Markdown = "^3.0.0"
 Mako = "^1.1"
 hug = "^2.6"
 docstring_parser = "^0.7.2"
-dataclasses = { version="^0.7", python="^3.6, <3.7" }
+dataclasses = { version=">=0.7", python="^3.6, <3.7" }
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.720.0"


### PR DESCRIPTION
Dataclasses v0.8 has been out since 2020-11-13. A package which pins `^0.8` cannot be installed alongside a package which, like pdocs, pins `^0.7`, so I propose `>=0.7` in order to play nicely with other packages.