### PR TITLE
Add missing short and long descriptions for parsed class docstrings

### DIFF
--- a/pdocs/templates/text.mako
+++ b/pdocs/templates/text.mako
@@ -118,14 +118,28 @@ class ${cls.name}(
     ${",\n    ".join(cls.params())}
 )
 ```
+<%
+    cls_pd = cls.parsed_docstring
+    if cls_pd:
+        short_desc = cls_pd.short_description
+        long_desc = cls_pd.long_description
+        params = cls_pd.params
+%>
 
-% if cls.parsed_docstring:
-    % if cls.parsed_docstring.params:
+% if cls_pd:
+    % if short_desc:
+${short_desc}
+
+    % endif
+    %if long_desc:
+${long_desc}
+    % endif
+    % if params:
 ${h4("Attributes")}
 
 | Name | Type | Description | Default |
 |---|---|---|---|
-        % for p in cls.parsed_docstring.params:
+        % for p in params:
 | ${p.arg_name} | ${p.type_name} | ${p.description} | ${p.default} |
         % endfor
     % endif


### PR DESCRIPTION
Fixes #33

The display function for classes only takes the params from the parsed docstring and skips the short and long description. This pull request fixes that to make the behaviour similar to how it already worked for functions.